### PR TITLE
Fix links after org rename

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
             <p><strong>Date:</strong> 26th July, 2025<br>
             <strong>Place:</strong> Virtual</p>
             <p>
-              <a href="https://github.com/SciPy-India/proposal-reviewing/issues/new?template=talk-proposal.yaml">Submit a talk here</a> | 
+              <a href="https://github.com/scipy-india/proposal-reviewing/issues/new?template=talk-proposal.yaml">Submit a talk here</a> | 
               <a href="#">RSVP - coming soon!</a>
             </p>
           </div>
@@ -69,7 +69,7 @@
     <a href="https://bsky.app/profile/scipyindia.bsky.social" target="_blank">Bluesky</a> |
     <a href="https://www.linkedin.com/company/scipyindia" target="_blank">LinkedIn</a> |
     <a href="https://fosstodon.org/@scipyindia" target="_blank">Mastodon</a> |
-    <a href="https://github.com/orgs/SciPy-India/discussions" target="_blank">GitHub Discussions</a>
+    <a href="https://github.com/orgs/scipy-india/discussions" target="_blank">GitHub Discussions</a>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
We renamed SciPy-India to scipy-india. GitHub sets up redirects for us automatically, but I don't think we should rely on them.