### PR TITLE
fix: missing `=` in hyperlink to NumFOCUS CoC

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 
     <section id="code-of-conduct">
       <h2>Code of Conduct</h2>
-      <p>The SciPy India community strictly follows the <a href"https://numfocus.org/code-of-conduct">NumFOCUS' Code of Conduct</a>. To make a report on any potential violation of our Code of Conduct, please fill out <a href="https://form.jotform.com/scipyindia/scipy-india-coc-reporting-form">this report form</a> to the best of your ability. For more visit <a href="https://github.com/scipy-india/.github/blob/main/CODE_OF_CONDUCT.md">SciPy India's CoC</a>.</p>
+      <p>The SciPy India community strictly follows the <a href="https://numfocus.org/code-of-conduct">NumFOCUS' Code of Conduct</a>. To make a report on any potential violation of our Code of Conduct, please fill out <a href="https://form.jotform.com/scipyindia/scipy-india-coc-reporting-form">this report form</a> to the best of your ability. For more visit <a href="https://github.com/scipy-india/.github/blob/main/CODE_OF_CONDUCT.md">SciPy India's CoC</a>.</p>
     </section>
     
     <hr>


### PR DESCRIPTION
Added a `=` in NumFOCUS CoC hyperlink