### PR TITLE
Add a blog post that describes what we are all about

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,0 +1,66 @@
+# About SciPy India
+
+## What is SciPy India?
+
+SciPy India is a community-driven initiative that aims to promote the practice of scientific computing in India. It is part of the larger SciPy ecosystem, which includes various conferences, workshops, and online resources dedicated to the Python programming language and its applications in science and engineering, emerging from the popular SciPy package for scientific computing in Python. SciPy India focuses on fostering a vibrant community of researchers, scientists, programmers, and learners, with a focus on the Indian context of free and open source software (FOSS) and open science, and its significance in the Indian research and development landscape.
+
+## Mission
+
+Our mission is to foster a collaborative environment where researchers, scientists, software engineers, learners, and enthusiasts alike can come together to share knowledge, collaborate on projects, and advance the field of scientific computing. We aim to provide resources, organise events, and create opportunities for learning and networking within the Indian scientific community, bridging both academia and industry.
+
+Primarily, we focus on:
+
+- Promoting the use of the Python programming language and its scientific libraries in research and development across India
+- Encouraging contributions and collaborations among Indian researchers and developers in the world of free and open source software, and building a strong network of professionals and enthusiasts in the field of scientific computing in India
+- Organising events, workshops, and conferences, and engaging in outreach activities to facilitate knowledge sharing and skill development in scientific computing
+- Advocating for access to open data, open research, open code, and open science practices in India within both academia and industry
+- and more!
+
+## SciPy India over the years
+
+SciPy India has been active since its inception in 2009, organising the SciPy India conference as a means to support the scientific computing fraternity in India. The conference has served as a platform for researchers, scientists, and developers to present their work, share ideas, and learn from each other, combining education, engineering, and science with computing through the medium of Python. Over the years, SciPy India has grown into a vibrant community with members from diverse backgrounds, including academia, industry, and government institutions.
+
+The first edition of the SciPy India conference was held in 2009 at SPACE Kerala, Trivandrum, India, and has since then become an annual event that has attracted participants from all over the country at various locations and venues, including the Indian School of Business (ISB) in Hyderabad, India, and the Indian Institute of Technology (IIT) Bombay in Mumbai, India. Each conference has featured keynote speakers, technical sessions, and networking opportunities for attendees.
+
+Post 2020, with the onset of the COVID-19 pandemic, SciPy India adapted to the new normal by transitioning to virtual events. This shift allowed the community to continue this mission of promoting scientific computing in India despite the challenges posed by an online format.
+
+SciPy India 2021 was the last edition of the conference held virtually, and since then, the community has been on a hiatus. However, come to 2025, we are thrilled to announce the revival of SciPy India with plans to host the next conference in 2025. We are currently in the planning stages, and we are excited to announce that we plan to resume in-person conferences in the near future, while also exploring hybrid formats to accommodate a wider audience.
+
+However, what are we doing in the meantime, you ask? Read on!
+
+### SciPy India community calls
+
+<!-- link to other blog post about first community call with more details) -->
+
+One of the key initiatives we have undertaken to keep the community engaged is the introduction of regular community calls. These calls serve as a platform for members to connect, share updates, discuss ongoing projects, and explore new ideas in the field of scientific computing. The community calls are open to all members and are held monthly, providing an opportunity for continuous learning and collaboration.
+
+We kicked off our first community call of 2025 on July 26th, 2025, with an engaging session that included updates from the community, presentations on recent projects, and discussions on future plans. The call was well-received, and we had a great turnout of participants from various backgrounds. We plan to continue these community calls on a regular basis, and we encourage all members to join in and contribute to the discussions.
+
+<!-- [Please click here to read more about our first community call](https://scipy-india.github.io/blog/events/community-call-july-2025.html/) -->
+
+### Conference
+
+In addition to community calls, we are also exploring other ways to keep the momentum going and engage with our community. This includes planning for future conferences, workshops, and events that will bring together experts and enthusiasts in the field of scientific computing. We are also looking into collaborations with other organisations and communities across languages and dialects to expand our reach and impact.
+
+Provided enough interest and support, we aim to host the next edition of the SciPy India conference, in person, in either late 2025 or early 2026. The conference, as always, will feature a mix of keynote speakers, technical sessions, and networking opportunities for attendees. We are currently in the planning stages and will be sharing more details in the coming months as we finalise the venue, dates, and call for proposals, and we could definitely use your help in making this happen!
+
+Stay tuned for more updates on our upcoming initiatives and events, and keep spreading the word about SciPy India! Please reach out to us if you have any ideas, suggestions, or would like to get involved in our community activities via our [contact page](https://scipy-india.github.io/contact.html/).
+
+<!-- link to contact page here, should be at https://scipy-india.github.io/contact.html/ -->
+
+## Community
+
+SciPy India is built on the principles of inclusivity, collaboration, and open access to knowledge. We welcome individuals from diverse backgrounds, including students, professionals, academics, and hobbyists who share a passion for scientific computing and data science.
+
+## Thanks, but how can I contribute?
+
+There are several ways you can contribute to SciPy India in 2025 and beyond:
+
+- **Join the community**: Participate in our online forum on [Zulip](https://scipy-india.github.io/contact.html/), and interact with social media channels to connect with other members and stay updated on the latest news and events.
+- **Attend events**: Participate in our community calls, workshops, and events to learn about the latest developments in scientific Python, including new libraries, tools, and techniques, and learn new skills and network with like-minded individuals.
+- **Organise events**: Help us organise local meetups, workshops, or conferences in your area to promote scientific computing with Python and foster a sense of community beyond virtual barriers.
+- **Contribute to open source**: Get involved in open source software projects related to scientific computing and data science. You can contribute code, documentation, or help with testing and bug reporting, and eventually, help us with our own website and infrastructure.
+- **Share knowledge**: Write blog posts (we're open to guest posts!), create tutorials, organise workshops, or speak on topics related to scientific computing and share your expertise with the SciPy India community.
+- **Volunteer**: Offer your time and skills at your convenience to help with various community initiatives, such as event planning, outreach, curation, graphics, social media management, grant writing, or the maintenance of this website.
+- **Spread the word**: Help us promote SciPy India by sharing our events and resources with your network.
+<!-- - **Donate**: Support our initiatives financially to help us organise events and provide resources to the community. -->


### PR DESCRIPTION
This PR adds a blog post that is intended to serve as content for an "About" page for our website. I've included sections about the erstwhile SciPy India events, what our mission is, and how people can join.

This is ready for review and feedback; however, let's wait to merge this until @malayajac completes her restructuring of the website's homepage.