### PR TITLE
feat (renderer): handle nested formatting inside Markdown link text

### DIFF
--- a/markdown.js
+++ b/markdown.js
@@ -257,10 +257,10 @@ class Renderer {
     const patterns = [
       { regex: /!\[([^\]]*)\]\(([^)]+)\)/g, type: "image" }, // ![alt](url)
       { regex: /\[([^\]]+)\]\(([^)]+)\)/g, type: "link" }, // [text](url)
+      { regex: /`([^`]+)`/g, type: "code" }, // `text`
       { regex: /\*\*([^*]+)\*\*/g, type: "bold" }, // **text**
       { regex: /\*([^*]+)\*/g, type: "italic" }, // *text*
       { regex: /_([^_]+)_/g, type: "italic" }, // _text_
-      { regex: /`([^`]+)`/g, type: "code" }, // `text`
     ];
 
     let earliest = null;
@@ -309,19 +309,36 @@ class Renderer {
       case "link":
         const link = document.createElement("a");
         link.href = this.sanitiseUrl(url);
-        link.textContent = content;
+
+        // Parse link content; we need to deal with nested formatting
+        // like [**bold link**](url) or [*italic link*](url) in links.
+        const linkElements = this.parseInlineMarkdown(content);
+        linkElements.forEach((element) => {
+          link.appendChild(element);
+        });
+
         link.target = "_blank";
         link.rel = "noopener noreferrer";
         return link;
 
       case "bold":
         const bold = document.createElement("strong");
-        bold.textContent = content;
+
+        const boldElements = this.parseInlineMarkdown(content);
+        boldElements.forEach((element) => {
+          bold.appendChild(element);
+        });
+
         return bold;
 
       case "italic":
         const italic = document.createElement("em");
-        italic.textContent = content;
+
+        const italicElements = this.parseInlineMarkdown(content);
+        italicElements.forEach((element) => {
+          italic.appendChild(element);
+        });
+
         return italic;
 
       case "code":


### PR DESCRIPTION
As stated in the title. I observed this on https://scipy-india.github.io/blogs.html?id=community-call-july-2025 – we did not handle this properly, this PR makes it do that. Screenshots below:

| Before | After |
|--------|--------|
| <img width="782" height="419" alt="image" src="https://github.com/user-attachments/assets/cc3a2d51-91b7-4b0b-b04a-a3cb77527e36" /> | <img width="767" height="419" alt="image" src="https://github.com/user-attachments/assets/fb29f7e1-d478-4c07-bb79-191c1034cec4" /> |