### PR TITLE
Fix rsvp link for October community call

### DIFF
--- a/event_details.json
+++ b/event_details.json
@@ -14,7 +14,7 @@
         "time": "10:00 AM - 12:00 PM IST / 4:30 AM - 6:30 AM UTC",
         "location": "Online",
         "cfp_link": "https://github.com/scipy-india/proposal-reviewing/issues/new?template=talk-proposal.yaml",
-        "rsvp_link": "https://fossunited.org/c/scipy-india/september-2025/rsvp"
+        "rsvp_link": "https://fossunited.org/c/scipy-india/community-call-2/rsvp"
     },
     {
         "title": "SciPy India Virtual Meetup #1",

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 
     <section id="code-of-conduct">
       <h2>Code of Conduct</h2>
-      <p>The SciPy India community strictly follows the <a href"https://numfocus.org/code-of-conduct">NumFOCUS' Code of Conduct</a>. To make a report on any potential violation of our Code of Conduct, please fill out <a href="https://form.jotform.com/scipyindia/scipy-india-coc-reporting-form">this report form</a> to the best of your ability. For more visit <a href="https://github.com/scipy-india/.github/blob/main/CODE_OF_CONDUCT.md">SciPy India's CoC</a>.</p>
+      <p>The SciPy India community strictly follows the <a href="https://numfocus.org/code-of-conduct">NumFOCUS' Code of Conduct</a>. To make a report on any potential violation of our Code of Conduct, please fill out <a href="https://form.jotform.com/scipyindia/scipy-india-coc-reporting-form">this report form</a> to the best of your ability. For more visit <a href="https://github.com/scipy-india/.github/blob/main/CODE_OF_CONDUCT.md">SciPy India's CoC</a>.</p>
     </section>
     
     <hr>


### PR DESCRIPTION
Fix broken RSVP link on our webpage that redirects to: https://fossunited.org/c/scipy-india/september-2025/rsvp instead of https://fossunited.org/c/scipy-india/community-call-2/rsvp+

Unsure why other commits are picked up but git diff shows only the relevant fix implemented.