### PR TITLE
Update timings for community call #2

### DIFF
--- a/event_details.json
+++ b/event_details.json
@@ -11,7 +11,7 @@
         "title": "SciPy India Community Call #2",
         "date": "04 October, 2025",
         "day": "Saturday",
-        "time": "10:00 AM - 12:00 PM IST / 4:30 AM - 6:30 AM UTC",
+        "time": "02:00 PM - 04:00 PM IST / 8:30 AM - 10:30 AM UTC",
         "location": "Online",
         "cfp_link": "https://github.com/scipy-india/proposal-reviewing/issues/new?template=talk-proposal.yaml",
         "rsvp_link": "https://fossunited.org/c/scipy-india/community-call-2/rsvp"


### PR DESCRIPTION
The timings were updated on the FOSS United event page (https://fossunited.org/c/scipy-india/community-call-2) and on the socials posts, but they weren't updated on the scipy India landing page.

This PR fixes the timings. the call is now from 2-4 PM IST