### PR TITLE
render: blog on website

### DIFF
--- a/blogs.js
+++ b/blogs.js
@@ -21,6 +21,17 @@ const blogConfig = [
     icon: "📞",
     readTime: "5 min read",
   },
+  {
+    id: "indiafoss-2025-science-devroom",
+    title: "IndiaFOSS 2025 | Devroom – FOSS in Science",
+    excerpt:
+      "A full day of talks at the FOSS In Science Devroom at IndiaFOSS 2025.",
+    markdownFile: "blogs/community-calls/indiafoss-2025-science-devroom.md",
+    date: "2025-09-21",
+    tags: ["Conference", "IndiaFOSS", "FOSS in Science"],
+    icon: "🔬",
+    readTime: "15 min read",
+  },
 ];
 
 class BlogsRenderer {


### PR DESCRIPTION
Add the latest devroom blog info to the `blogs.js` website for it to render on our [blogs webpage](https://scipy-india.github.io/blogs.html).