### PR TITLE
nit: remove duplicate timings listed for IST in devroom blog post event details

### DIFF
--- a/event_details.json
+++ b/event_details.json
@@ -21,7 +21,7 @@
         "title": "FOSS in Science Devroom at IndiaFOSS 2025",
         "date": "21 September, 2025",
         "day": "Sunday",
-        "time": "10:00 AM to 1:00 PM IST IST / 10:00 AM to 1:00 PM IST / 04:30 AM – 07:30 AM UTC",
+        "time": "10:00 AM to 1:00 PM IST / 04:30 AM – 07:30 AM UTC",
         "location": "NIMHANS Convention Centre, Bengaluru, India",
         "cfp_link": "https://fossunited.org/indiafoss/2025/devrooms/science",
         "rsvp_link": "https://fossunited.org/indiafoss/2025/devrooms/science",


### PR DESCRIPTION
<img width="691" height="271" alt="image" src="https://github.com/user-attachments/assets/265c1267-53eb-49a9-9708-8e3811bab1ec" />

Introduced in #39 ([diff](https://github.com/scipy-india/scipy-india.github.io/pull/39/files#diff-647417490f269cd855e7c36f8d46f9087c8ae484f43e59f771199599ee8ab3eaR24)).