### PR TITLE
Use FontAwesome v7 and add Zulip and Bluesky icons

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,13 +61,13 @@ html_theme_options = {
         {
             "name": "Zulip",
             "url": "https://scipyindia.zulipchat.com/join/4mesdxfbbpl4titgtdzx4iwv/",
-            "icon": "fas fa-comments",
+            "icon": "fa-brands fa-zulip",
             "type": "fontawesome",
         },
         {
             "name": "Bluesky",
             "url": "https://bsky.app/profile/scipyindia.bsky.social",
-            "icon": "fas fa-cloud",
+            "icon": "fa-brands fa-bluesky",
             "type": "fontawesome",
         },
         {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,6 @@ extensions = [
 ]
 
 html_static_path = ["_static"]
-html_css_files = [
-    "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.2.0/css/all.min.css",
-]
 html_js_files = [
     (
         "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.2.0/js/brands.min.js",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,15 @@ extensions = [
 ]
 
 html_static_path = ["_static"]
+html_css_files = [
+    "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.2.0/css/all.min.css",
+]
+html_js_files = [
+    (
+        "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.2.0/js/brands.min.js",
+        {"defer": "defer"},
+    ),
+]
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_show_sourcelink = False


### PR DESCRIPTION
Overrides the FontAwesome v6 present in the theme with v7 and adds Zulip and Bluesky icons. Follow-up to #53.

Can be partially reverted after https://github.com/pydata/pydata-sphinx-theme/issues/2317 is resolved and released.