### PR TITLE
Fix title and update copyright, remove duplicate title on main page

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,3 +1,5 @@
-{% extends "!layout.html" %} {% block htmltitle %} {% if pagename == "index" %} <title>SciPy India</title> {% else %} {{ super() }} {% endif %} {% endblock htmltitle %} {% block docs_sidebar %} {% if pagename != "index"
-%} {{ super() }} {% endif %} {% endblock docs_sidebar %} {% block docs_toc %} {%
-if pagename != "index" %} {{ super() }} {% endif %} {% endblock %}
+{% extends "!layout.html" %} {% block htmltitle %} {% if pagename == "index" %}
+<title>SciPy India</title> {% else %} {{ super() }} {% endif %} {% endblock
+htmltitle %} {% block docs_sidebar %} {% if pagename != "index" %} {{ super() }}
+{% endif %} {% endblock docs_sidebar %} {% block docs_toc %} {% if pagename !=
+"index" %} {{ super() }} {% endif %} {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,3 +1,3 @@
-{% extends "!layout.html" %} {% block docs_sidebar %} {% if pagename != "index"
+{% extends "!layout.html" %} {% block htmltitle %} {% if pagename == "index" %} <title>SciPy India</title> {% else %} {{ super() }} {% endif %} {% endblock htmltitle %} {% block docs_sidebar %} {% if pagename != "index"
 %} {{ super() }} {% endif %} {% endblock docs_sidebar %} {% block docs_toc %} {%
 if pagename != "index" %} {{ super() }} {% endif %} {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 project = "SciPy India"
-copyright = "2026, SciPy India Contributors"
-author = "SciPy India Contributors"
+html_title = "SciPy India"
+copyright = "2026, The SciPy India team"
+author = "The SciPy India team"
 
 html_theme = "pydata_sphinx_theme"
 


### PR DESCRIPTION
- Updates copyright and author to say "Team" instead of "Contributors"
- Removes a quirk of the theme where we'll have the website title as "SciPy India – SciPy India". I don't like the duplication a lot