### PR TITLE
Reposition sections on the front page

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,5 +4,6 @@
 />{% endblock extrahead %} {% block htmltitle %} {% if pagename == "index" %}
 <title>SciPy India</title> {% else %} {{ super() }} {% endif %} {% endblock
 htmltitle %} {% block docs_sidebar %} {% if pagename != "index" %} {{ super() }}
-{% endif %} {% endblock docs_sidebar %} {% block docs_toc %} {% if pagename !=
-"index" %} {{ super() }} {% endif %} {% endblock %}
+{% endif %} {% endblock docs_sidebar %} {% block docs_toc %} {% if pagename ==
+"index" %} {% include "recent-highlights.html" %} {% else %} {{ super() }} {%
+endif %} {% endblock %}

--- a/docs/_templates/recent-highlights.html
+++ b/docs/_templates/recent-highlights.html
@@ -8,7 +8,10 @@
           ><strong>{{ post.title }}</strong></a
         >
       </p>
-      <p class="small mb-0"><em>{{ post.date.strftime('%d %b %Y') }}</em></p>
+      <p class="small mb-0">
+        <em>{{ post.date.strftime('%d %b %Y') }}</em>{% if post.category %} · {%
+        for coll in post.category %}{{ coll }}{% endfor %}{% endif %}
+      </p>
     </div>
     {% endif %} {% endfor %}
   </div>

--- a/docs/_templates/recent-highlights.html
+++ b/docs/_templates/recent-highlights.html
@@ -1,30 +1,16 @@
 <div class="sidebar-secondary-item">
   <h3>Recent highlights</h3>
   <div class="d-flex flex-column gap-3">
+    {% for post in ablog.posts %} {% if loop.index0 < 5 %}
     <div>
       <p class="mb-1">
-        <a href="{{ pathto('blog/2026-02-21-bangpypers-joint-meetup') }}"
-          ><strong>BangPypers × SciPy India Meetup</strong></a
+        <a href="{{ pathto(post.docname) }}"
+          ><strong>{{ post.title }}</strong></a
         >
       </p>
-      <p class="small mb-1"><em>21 Feb 2026</em> · Debrief</p>
-      <p class="small mb-0">
-        Our first offline joint meetup, with talks on LLM systems, NumPy
-        contributions, and Python metaprogramming.
-      </p>
+      <p class="small mb-0"><em>{{ post.date.strftime('%d %b %Y') }}</em></p>
     </div>
-    <div>
-      <p class="mb-1">
-        <a href="{{ pathto('blog/2025-09-21-indiafoss-science-devroom') }}"
-          ><strong>FOSS in Science Devroom at IndiaFOSS 2025</strong></a
-        >
-      </p>
-      <p class="small mb-1"><em>21 Sep 2025</em> · Debrief</p>
-      <p class="small mb-0">
-        A full day of talks on FOSS in scientific research, co-organised at
-        IndiaFOSS 2025 in Bengaluru.
-      </p>
-    </div>
+    {% endif %} {% endfor %}
   </div>
   <p class="mt-3 mb-0">
     <a href="{{ pathto('blog/index') }}">Read the blog →</a>

--- a/docs/_templates/recent-highlights.html
+++ b/docs/_templates/recent-highlights.html
@@ -1,0 +1,32 @@
+<div class="sidebar-secondary-item">
+  <h3>Recent highlights</h3>
+  <div class="d-flex flex-column gap-3">
+    <div>
+      <p class="mb-1">
+        <a href="{{ pathto('blog/2026-02-21-bangpypers-joint-meetup') }}"
+          ><strong>BangPypers × SciPy India Meetup</strong></a
+        >
+      </p>
+      <p class="small mb-1"><em>21 Feb 2026</em> · Debrief</p>
+      <p class="small mb-0">
+        Our first offline joint meetup, with talks on LLM systems, NumPy
+        contributions, and Python metaprogramming.
+      </p>
+    </div>
+    <div>
+      <p class="mb-1">
+        <a href="{{ pathto('blog/2025-09-21-indiafoss-science-devroom') }}"
+          ><strong>FOSS in Science Devroom at IndiaFOSS 2025</strong></a
+        >
+      </p>
+      <p class="small mb-1"><em>21 Sep 2025</em> · Debrief</p>
+      <p class="small mb-0">
+        A full day of talks on FOSS in scientific research, co-organised at
+        IndiaFOSS 2025 in Bengaluru.
+      </p>
+    </div>
+  </div>
+  <p class="mt-3 mb-0">
+    <a href="{{ pathto('blog/index') }}">Read the blog →</a>
+  </p>
+</div>

--- a/docs/blog/2026-02-21-bangpypers-joint-meetup.md
+++ b/docs/blog/2026-02-21-bangpypers-joint-meetup.md
@@ -2,7 +2,7 @@
 blogpost: true
 date: 2026-02-21
 author: Srihari Thyagarajan, Agriya Khetarpal
-category: Events
+category: Debrief
 tags: [meetup, bangpypers, bengaluru, offline]
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,3 @@
----
-html_theme.sidebar_secondary.remove: true
----
-
 # SciPy India
 
 Discover events, read community updates, and stay connected with the local scientific Python ecosystem.
@@ -25,31 +21,6 @@ Details to be announced. Watch this space.
 ::::
 
 [View all events →](events/index)
-
-## Recent highlights
-
-::::{grid} 1
-:gutter: 3
-
-:::{grid-item-card} BangPypers × SciPy India Meetup
-:link: blog/2026-02-21-bangpypers-joint-meetup
-:link-type: doc
-
-_21 Feb 2026_ · Debrief
-
-Our first offline joint meetup, with talks on LLM systems, NumPy contributions, and Python metaprogramming.
-:::
-
-:::{grid-item-card} FOSS in Science Devroom at IndiaFOSS 2025
-:link: blog/2025-09-21-indiafoss-science-devroom
-:link-type: doc
-
-_21 Sep 2025_ · Debrief
-
-A full day of talks on FOSS in scientific research, co-organised at IndiaFOSS 2025 in Bengaluru.
-:::
-
-::::
 
 ## Partners & support
 


### PR DESCRIPTION
This PR repositions the "Recent highlights" section on the front page to appear in the location of the secondary sidebar on the right-hand side instead. My intention is that we should make our "Parners & support" section more prominent so that users don't need to scroll down to see them, as it currently happens on https://scipy.in.

I added a custom layout via `docs/_templates/recent-highlights.html` that just loops over what we have set up through ABlog in #53. I bumped it to include 5 highlights, from 2, now that we will have more space. Another PR will follow, where I will automate the "Blogs" page.

Compare:
- Before: https://scipy.in
- After: https://deploy-preview-66--scipy-india.netlify.app/