### PR TITLE
Override ABlog with a custom Sphinx extension to include descriptions from individual blog posts

### DIFF
--- a/docs/_extra/blog.html
+++ b/docs/_extra/blog.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=blog/index.html" />
+    <link rel="canonical" href="blog/index.html" />
+    <title>Blog — SciPy India</title>
+    <script>
+      window.location.replace("blog/index.html");
+    </script>
+  </head>
+  <body>
+    <noscript>
+      <p><a href="blog/index.html">Click here if you are not redirected.</a></p>
+    </noscript>
+  </body>
+</html>

--- a/docs/_templates/ablog/collection.html
+++ b/docs/_templates/ablog/collection.html
@@ -1,0 +1,59 @@
+{%- extends "page.html" %} {% block body %} {% macro postlink(post) -%} {% if
+post.external_link -%} {{- post.external_link -}} {% else %} {{-
+pathto(post.docname) }}{{ anchor(post) -}} {%- endif %} {%- endmacro %}
+<div class="section ablog__collection">
+  <h1>
+    {% if archive_feed and fa %}
+    <a href="{{ pathto(collection.path, 1) }}/atom.xml">
+      <i class="fa fa-rss fa-rotate-270"></i
+    ></a>
+    {% endif %}
+    <span
+      >{{ header }} {% if collection.href %}
+      <a href="{{ collection.href }}">{{ collection }}</a>
+      {% else %} {{ collection }} {% endif %}
+    </span>
+  </h1>
+  {% if ablog.blog_archive_titles %} {% for post in collection %}
+  <div class="section ablog__collection_meta">
+    <p>
+      {% if post.published %}
+      <span>{{ post.date.strftime(ablog.post_date_format) }}</span>
+      {% else %}
+      <span>Draft</span>
+      {% endif %} -
+      <a href="{{ postlink(post) }}">{{ post.title }}</a>
+    </p>
+  </div>
+  {% endfor %} {% else %} {% for post in collection %}
+  <div class="section ablog-post">
+    <h2 class="ablog-post-title">
+      <a href="{{ postlink(post) }}">{{ post.title }}</a>
+    </h2>
+    <ul class="ablog-archive">
+      <li>
+        {% if post.published %} {% if fa %}
+        <i class="fa fa-calendar"></i>
+        {% endif %}
+        <span>{{ post.date.strftime(ablog.post_date_format) }}</span>
+        {% else %} {% if fa %}
+        <i class="fa fa-pencil"></i>
+        {% endif %} {% if post.date %}
+        <span>{{ post.date.strftime(ablog.post_date_format) }}</span>
+        {% else %}
+        <span>Draft</span>
+        {% endif %} {% endif %}
+      </li>
+      {% include "ablog/postcard2.html" %}
+    </ul>
+    {% set desc = post_descriptions.get(post.docname, "") %} {% if desc %}
+    <p>{{ desc }}</p>
+    {% else %} {{ post.to_html(collection.docname) }} {% endif %}
+    <p class="ablog-post-expand">
+      <a href="{{ postlink(post) }}"><em>{{ _("Read more ...") }}</em></a>
+    </p>
+    <hr />
+  </div>
+  {% endfor %} {% endif %}
+</div>
+{% endblock body %}

--- a/docs/_templates/blog_post_grid_body.html
+++ b/docs/_templates/blog_post_grid_body.html
@@ -1,0 +1,30 @@
+<!-- This is exactly the same grid body as ABlog, but with an extra description
+field which we populate from the blog posts' frontmatter. -->
+{% macro postlink(post) -%}{{ pathto(post.docname) }}{%- endmacro %}
+<div class="ablog__collection">
+  {% for post in collection %}
+  <div class="section ablog-post">
+    <h2 class="ablog-post-title">
+      <a href="{{ postlink(post) }}">{{ post.title }}</a>
+    </h2>
+    <ul class="ablog-archive">
+      <li>
+        {% if post.published %} {% if fa %}<i class="fa fa-calendar"></i>{%
+        endif %}
+        <span>{{ post.date.strftime(ablog.post_date_format) }}</span>
+        {% else %}
+        <span>Draft</span>
+        {% endif %}
+      </li>
+      {% include "ablog/postcard2.html" %}
+    </ul>
+    {% set desc = post_descriptions.get(post.docname, "") %} {% if desc %}
+    <p>{{ desc }}</p>
+    {% else %}{{ post.to_html(pagename) }}{% endif %}
+    <p class="ablog-post-expand">
+      <a href="{{ postlink(post) }}"><em>Read more ...</em></a>
+    </p>
+    <hr />
+  </div>
+  {% endfor %}
+</div>

--- a/docs/blog/2025-07-26-community-call-1.md
+++ b/docs/blog/2025-07-26-community-call-1.md
@@ -4,6 +4,7 @@ date: 2025-07-26
 author: Agriya Khetarpal, Aditi Juneja, Srihari Thyagarajan
 category: Community Calls
 tags: [community-call, meetup, pycaret, marimo, causal-ml]
+description: Our first online community call, with talks on PyCaret, marimo, causal ML, and the kinds of conversations that shaped what came next.
 ---
 
 # SciPy India Community Call #1 – July 2025

--- a/docs/blog/2025-09-21-indiafoss-science-devroom.md
+++ b/docs/blog/2025-09-21-indiafoss-science-devroom.md
@@ -4,6 +4,7 @@ date: 2025-09-21
 author: Srihari Thyagarajan, Agriya Khetarpal
 category: Events
 tags: [indiafoss, devroom, bengaluru, foss-in-science]
+description: A full debrief from the FOSS in Science devroom at IndiaFOSS 2025, including the talks, themes, and links to individual recordings.
 ---
 
 # IndiaFOSS 2025 | Devroom – FOSS in Science

--- a/docs/blog/2026-02-21-bangpypers-joint-meetup.md
+++ b/docs/blog/2026-02-21-bangpypers-joint-meetup.md
@@ -18,8 +18,8 @@ There's been a [running conversation](https://github.com/scipy-india/planning/is
 - **Date**: February 21st, 2026
 - **Time**: 11:00 to 14:30 IST
 - **Venue**: [Amadeus Software Labs India Pvt Ltd, Kadubeesanahalli, Marathahalli, Bengaluru](https://osmapp.org/node/4672131190)
-- **Meetup page**: [SciPy India × BangPypers meetup](https://www.meetup.com/bangpybers/events/311155506/)
-- **Photos**: [Meetup photos](https://www.meetup.com/bangpybers/photos/35845246/)
+- **Meetup page**: [SciPy India × BangPypers meetup](https://www.meetup.com/bangpypers/events/311155506/)
+- **Photos**: [Meetup photos](https://www.meetup.com/bangpypers/photos/35845246/)
 
 ## Photo album
 

--- a/docs/blog/2026-02-21-bangpypers-joint-meetup.md
+++ b/docs/blog/2026-02-21-bangpypers-joint-meetup.md
@@ -4,6 +4,7 @@ date: 2026-02-21
 author: Srihari Thyagarajan, Agriya Khetarpal
 category: Events
 tags: [meetup, bangpypers, bengaluru, offline]
+description: An afternoon in Bengaluru with talks on reliable LLM systems, NumPy maintenance, Python metaprogramming, and lightning talks.
 ---
 
 # SciPy India × BangPypers Meetup, February 2026

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -4,39 +4,10 @@ blogpost: false
 
 # Blog
 
-Event recaps and write-ups from the community.
+Here is a list of recaps and write-ups from the SciPy India community. If you have a post that you would like to share, please submit a [pull request](https://github.com/scipy-india/scipy-india.github.io) to add it here!
 
-::::{grid} 1
-:gutter: 3
-
-:::{grid-item-card} SciPy India × BangPypers Meetup, February 2026
-:link: 2026-02-21-bangpypers-joint-meetup
-:link-type: doc
-
-*21 Feb 2026* · Recap
-
-An afternoon in Bengaluru with talks on reliable LLM systems, NumPy maintenance, Python metaprogramming, and lightning talks.
-:::
-
-:::{grid-item-card} IndiaFOSS 2025 | Devroom – FOSS in Science
-:link: 2025-09-21-indiafoss-science-devroom
-:link-type: doc
-
-*21 Sep 2025* · Recap
-
-A full debrief from the FOSS in Science devroom at IndiaFOSS 2025, including the talks, themes, and links to individual recordings.
-:::
-
-:::{grid-item-card} SciPy India Community Call #1, July 2025
-:link: 2025-07-26-community-call-1
-:link-type: doc
-
-*26 Jul 2025* · Recap
-
-Our first online community call, with talks on PyCaret, marimo, causal ML, and the kinds of conversations that shaped what came next.
-:::
-
-::::
+```{blog-post-grid}
+```
 
 ```{toctree}
 :hidden:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,9 @@
+import sys
+import os
+
+# Path for our custom Sphinx extensions
+sys.path.insert(0, os.path.abspath("sphinxext"))
+
 project = "SciPy India"
 html_title = "SciPy India"
 copyright = "2026, The SciPy India team"
@@ -11,6 +17,7 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx_togglebutton",
+    "blog_post_grid",
 ]
 
 html_static_path = ["_static"]
@@ -30,6 +37,7 @@ html_sidebars = {
     "index": [],
     "contact": [],
     "coc": [],
+    "blog": [],
     "blog/**": [],
 }
 
@@ -95,3 +103,18 @@ blog_title = "SciPy India Blog"
 blog_baseurl = "https://scipy.in"
 blog_feed_fulltext = True
 blog_post_pattern = "blog/*.md"
+
+# Add post descriptions to the blog post grid context, because
+# ABlog doesn't do this by default.
+def _add_post_descriptions(app, _pagename, _templatename, context, _doctree):
+    from ablog.blog import Blog
+
+    blog = Blog(app)
+    context["post_descriptions"] = {
+        post.docname: app.env.metadata.get(post.docname, {}).get("description", "")
+        for post in blog.posts
+    }
+
+
+def setup(app):
+    app.connect("html-page-context", _add_post_descriptions)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,9 @@ extensions = [
 ]
 
 html_static_path = ["_static"]
+# Files in _extra/ are copied after the build and overwrite any generated files
+# with the same name. _extra/blog.html replaces ABlog's "All Posts" page with a
+# redirect to blog/index.html to keep a single canonical blog listing page.
 html_extra_path = ["_extra"]
 html_css_files = ["custom.css"]
 html_js_files = [

--- a/docs/sphinxext/blog_post_grid.py
+++ b/docs/sphinxext/blog_post_grid.py
@@ -1,0 +1,64 @@
+"""
+A Sphinx extension to render a grid of blog posts on the blog index page.
+
+We override ABlog's default grid body template to include an extra description field,
+which we populate from the blog posts' frontmatter metadata.
+
+This extension defines a custom directive `blog-post-grid`, which can be used in the blog
+index page to render the grid of blog posts. The directive is implemented using a custom
+node `BlogPostGridNode`, which is resolved during the `doctree-resolved` event to render
+the HTML for the grid using a custom template `blog_post_grid_body.html`.
+
+Maybe we can contribute this back to ABlog at some point if we think it's generally useful!
+"""
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from ablog import anchor
+
+
+class BlogPostGridNode(nodes.General, nodes.Element):
+    pass
+
+
+class BlogPostGrid(Directive):
+    required_arguments = 0
+    optional_arguments = 0
+    has_content = False
+    option_spec = {}
+
+    def run(self):
+        return [BlogPostGridNode()]
+
+
+def _resolve(app, doctree, docname):
+    from ablog.blog import Blog
+
+    for node in doctree.findall(BlogPostGridNode):
+        blog = Blog(app)
+        collection = sorted(blog.posts._posts.values(), reverse=True)
+        post_descriptions = {
+            post.docname: app.env.metadata.get(post.docname, {}).get("description", "")
+            for post in collection
+        }
+        context = {
+            "ablog": blog,
+            "fa": blog.fontawesome,
+            "pathto": lambda target, mode=0: app.builder.get_relative_uri(
+                docname, target
+            ),
+            "anchor": anchor,
+            "collection": collection,
+            "post_descriptions": post_descriptions,
+            "pagename": docname,
+            "_": lambda x: x,
+        }
+        html = app.builder.templates.render("blog_post_grid_body.html", context)
+        node.replace_self(nodes.raw("", html, format="html"))
+
+
+def setup(app):
+    app.add_node(BlogPostGridNode)
+    app.connect("doctree-resolved", _resolve)
+    app.add_directive("blog-post-grid", BlogPostGrid)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}


### PR DESCRIPTION
This PR continues the work I mentioned in #66. Currently, https://scipy.in/blog and https://scipy.in/blog/index.html have different content. Adding Netlify surfaced the problem because it uses ["Pretty URLs"](https://dev.to/victoreke/how-to-make-urls-pretty-using-netlify-1a4k), which are known to strip the `index.html` from a URL, leaving it bare. And the problem with ABlog is that it cannot render the descriptions we have, so I found it easier to just add a "Description" entry in the frontmatter of individual blog posts, and that can be collected by a custom Sphinx extension that overrides the default ABlog behaviour to parse that description.

Here's a table to summarise the difference:

| Webpage | Before | With this PR |
|--------|--------|--------|
| https://scipy.in/blog | Default ABlog "All Posts" layout, no blog post descriptions included | Both are the same now. We have a custom layout which is the same as before but with descriptions being automatically added from the blog posts. |
| https://scipy.in/blog/index.html | Our intended card-based layout, with descriptions manually added. This mirrors `index.md`. | The cards in `index.md` are removed and replaced with our custom directive. We have a custom layout (the one that ABlog has), just with descriptions being automatically added from the blog posts. | 