### PR TITLE
Various accessibility and performance fixes

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,23 @@
+@font-face {
+  font-family: "Font Awesome 6 Free";
+  font-style: normal;
+  font-weight: 900;
+  font-display: swap;
+  src:
+    url(vendor/fontawesome/webfonts/fa-solid-900.woff2) format("woff2"),
+    url(vendor/fontawesome/webfonts/fa-solid-900.ttf) format("truetype");
+}
+
+@font-face {
+  font-family: "Font Awesome 6 Brands";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src:
+    url(vendor/fontawesome/webfonts/fa-brands-400.woff2) format("woff2"),
+    url(vendor/fontawesome/webfonts/fa-brands-400.ttf) format("truetype");
+}
+
 img.partner-logo {
   vertical-align: top;
 }

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "About SciPy India — a community-driven initiative promoting scientific computing and open source software in India."
+---
+
 # About
 
 ## What is SciPy India?

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,5 +1,8 @@
 ---
 blogpost: false
+myst:
+  html_meta:
+    "description": "SciPy India Blog — recaps and write-ups from the scientific Python community in India."
 ---
 
 # Blog

--- a/docs/coc.md
+++ b/docs/coc.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "SciPy India Code of Conduct — our commitment to a welcoming, inclusive, and safe community for everyone."
+---
+
 # Code of Conduct
 
 Creating a welcoming, inclusive, and safe environment for everyone in our community.

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Contact the SciPy India team — reach out to community organisers and volunteers for inquiries and collaboration."
+---
+
 # Contact
 
 For general inquiries about SciPy India, collaboration opportunities, or if you're unsure who to contact, feel free to reach out through our community organisers and volunteers.

--- a/docs/events/index.md
+++ b/docs/events/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "SciPy India Events — upcoming and past conferences, community calls, and meetups from the scientific Python community in India."
+---
+
 # Events
 
 A quick overview of upcoming and recent events. Open a card for either a debrief or a short event page with the recording and core details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ We are incubated and supported by [the FOSS United Foundation](https://fossunite
 :alt: FOSSEE
 :width: 200px
 :target: https://fossee.in
-:class: me-4 partner-logo no-scaled-link
+:class: mb-3 partner-logo no-scaled-link
 ```
 
 ```{image} _static/partner-logos/iitb.svg

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ Details to be announced. Watch this space.
 ```{image} _static/partner-logos/psf.svg
 :alt: Python Software Foundation
 :height: 100px
+:width: 264px
 :target: https://www.python.org/psf
 :class: mb-3 no-scaled-link partner-logo
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "SciPy India — discover events, read community updates, and stay connected with the scientific Python ecosystem in India."
+---
+
 # SciPy India
 
 Discover events, read community updates, and stay connected with the scientific Python ecosystem in India.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,18 +43,11 @@ SciPy India is an [official community partner](https://www.python.org/psf/commun
 :::{grid-item-card}
 :text-align: center
 
-```{image} _static/partner-logos/fossunited-dark.svg
-:alt: FOSS United Foundation
-:height: 100px
-:target: https://fossunited.org/c/scipy-india
-:class: only-light mb-3 no-scaled-link partner-logo
-```
-
-```{image} _static/partner-logos/fossunited-light.svg
-:alt: FOSS United Foundation
-:height: 100px
-:target: https://fossunited.org/c/scipy-india
-:class: only-dark mb-3 no-scaled-link partner-logo
+```{raw} html
+<a href="https://fossunited.org/c/scipy-india" aria-label="FOSS United Foundation">
+  <img alt="" class="only-light mb-3 no-scaled-link partner-logo" src="_static/partner-logos/fossunited-dark.svg" style="height: 100px;" />
+  <img alt="" class="only-dark mb-3 no-scaled-link partner-logo" src="_static/partner-logos/fossunited-light.svg" style="height: 100px;" />
+</a>
 ```
 
 We are incubated and supported by [the FOSS United Foundation](https://fossunited.org), a Section 8 non-profit organisation that aims to promote and strengthen the Free and Open Source Software (FOSS) ecosystem in India.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,27 @@
 [build]
   command = "pip install uv && uv run sphinx-build -b html -W --keep-going docs/ _build/html"
   publish = "_build/html"
+
+# pydata-sphinx-theme JS (cache-busted via ?digest= query param)
+[[headers]]
+  for = "/_static/scripts/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# pydata-sphinx-theme CSS (cache-busted via ?digest= query param)
+[[headers]]
+  for = "/_static/styles/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Vendored FontAwesome fonts (cache-busted via digest in parent CSS)
+[[headers]]
+  for = "/_static/vendor/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Sphinx-processed images (no cache-busting; 1-week TTL)
+[[headers]]
+  for = "/_images/*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"


### PR DESCRIPTION
### Summary

This PR fixes several issues flagged in our Lighthouse report from 13 May 2026, see #22.

Also, closes #62. `me-4` (right margin) was pushing the FOSSEE image left of centre, while IITB had none. Changed to `mb-3` to match IITB and add a bit of vertical breathing room between the two logos.

**AI disclosure:** Claude Sonnet 4.6. I've reviewed all the changes it made.

#### Accessibility

- **Fix `link-name` audit**: The FOSS United logo section used two separate `{image}` directives, each with a `:target:` link. pydata-sphinx-theme's CSS hides inactive theme variants with `display: none` on the `<img>`, but the parent `<a>` stays in the accessibility tree with no accessible child. Replaced both image directives with a single `{raw} html` block using one `<a aria-label="FOSS United Foundation">` wrapping both images.

#### Performance

- **Fix `font-display` audit (est. 320 ms FCP savings)**: pydata-sphinx-theme bundles FontAwesome with `font-display: block`. Added `@font-face` overrides in `custom.css` with `font-display: swap` for Font Awesome 6 Free (Solid) and Font Awesome 6 Brands. CSS picks the last matching declaration, so this takes precedence over the theme's rules.

- **Fix `unsized-images` audit**: The PSF logo only had `height: 100px` set. The SVG uses `pt` units for its intrinsic dimensions, so the browser cannot determine the aspect ratio before the image loads. Added `:width: 264px` (matching the natural 4110.25:1559.06 ratio at 100px height) to let the browser reserve space.

- **Fix `cache-insight` audit (est. 928 KiB savings for repeat visits)**: Added `Cache-Control` headers in `netlify.toml` for Netlify. pydata-sphinx-theme scripts, styles, and vendor fonts are all cache-busted via `?digest=` query params, so they get `max-age=31536000, immutable`. Sphinx-processed images (`/_images/*`) have no cache-busting, so they get `max-age=604800` (1 week).

#### SEO

- **Fix `meta-description` audit**: Added `myst: html_meta` front matter with a page-specific description to all six top-level pages (`index.md`, `about.md`, `contact.md`, `coc.md`, `events/index.md`, `blog/index.md`).

---

#### Not addressed here

- `label-content-name-mismatch`: The theme switcher button text does not match its aria-label. This is a pydata-sphinx-theme upstream issue.
- `unminified-javascript`: Lighthouse flagged a `chrome-extension://` URL from the test browser, not our site's JS.
