### PR TITLE
Exclude IIT Bombay link from the checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,3 +9,4 @@ https://ebird\.org/home$
 https://stateofindiasbirds\.in/?$
 https://osmapp\.org/way/1219285692#15\.37/12\.9430/77\.5956$
 https://osmapp\.org/node/4672131190$
+https://www\.iitb\.ac\.in.*

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,4 +9,4 @@ https://ebird\.org/home$
 https://stateofindiasbirds\.in/?$
 https://osmapp\.org/way/1219285692#15\.37/12\.9430/77\.5956$
 https://osmapp\.org/node/4672131190$
-https://www\.iitb\.ac\.in.*
+https://www\.iitb\.ac\.in(/.*)?$


### PR DESCRIPTION
The link checker [fails](https://github.com/scipy-india/scipy-india.github.io/actions/runs/27732133746) on https://www.iitb.ac.in/ with a connection reset (os error 104).
It's not actually down, IIT Bombay's server just drops GitHub Actions' runner IPs. Works fine from a normal connection, so it's not something `--accept` or retries can fix.

Adds it to `.lycheeignore` alongside the other external / flaky hosts. 
Related #87 