### PR TITLE
Restore GitHub Pages redirect

### DIFF
--- a/.github/workflows/github-pages-redirect.yml
+++ b/.github/workflows/github-pages-redirect.yml
@@ -1,0 +1,39 @@
+name: Deploy GitHub Pages redirect
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/github-pages-redirect.yml"
+      - "github-pages/**"
+
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy redirect
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: github-pages
+
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/github-pages-redirect.yml
+++ b/.github/workflows/github-pages-redirect.yml
@@ -8,10 +8,7 @@ on:
       - ".github/workflows/github-pages-redirect.yml"
       - "github-pages/**"
 
-permissions:
-  contents: read
-  id-token: write
-  pages: write
+permissions: {}
 
 concurrency:
   group: github-pages
@@ -21,19 +18,23 @@ jobs:
   deploy:
     name: Deploy redirect
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
-      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: github-pages
 
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/github-pages/404.html
+++ b/github-pages/404.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="0; url=https://scipy.in/" />
+    <link rel="canonical" href="https://scipy.in/" />
+    <title>Redirecting to SciPy India</title>
+    <script>
+      const target = new URL("https://scipy.in/");
+      target.pathname = window.location.pathname;
+      target.search = window.location.search;
+      target.hash = window.location.hash;
+      window.location.replace(target.toString());
+    </script>
+  </head>
+  <body>
+    <p>
+      SciPy India has moved to
+      <a href="https://scipy.in/">https://scipy.in/</a>.
+    </p>
+  </body>
+</html>

--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="0; url=https://scipy.in/" />
+    <link rel="canonical" href="https://scipy.in/" />
+    <title>Redirecting to SciPy India</title>
+    <script>
+      const target = new URL("https://scipy.in/");
+      target.search = window.location.search;
+      target.hash = window.location.hash;
+      window.location.replace(target.toString());
+    </script>
+  </head>
+  <body>
+    <p>
+      SciPy India has moved to
+      <a href="https://scipy.in/">https://scipy.in/</a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
PR #78 moved the real site to Cloudflare Pages, but old scipy-india.github.io links are still around. This adds a tiny GitHub Pages artifact that sends those visitors to scipy.in, including deep links via the 404 page.

Test this locally:

```
python3 -m http.server 8000 -d github-pages
```

Then open http://localhost:8000. It should immediately send you to https://scipy.in/.

> [!NOTE]
> This local test intentionally redirects to `https://scipy.in/`. Python's simple HTTP server does not emulate GitHub Pages' custom `404.html` fallback, so deep-link behavior can be checked by opening `http://localhost:8000/404.html` directly. GitHub Pages itself will use that page for missing old paths.