### PR TITLE
Use compact search button to keep navbar on one row

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ html_theme_options = {
     "navbar_start": ["navbar-logo"],
     "navbar_center": ["navbar-nav"],
     "navbar_end": ["navbar-icon-links", "theme-switcher"],
+    "navbar_persistent": ["search-button"],
     "footer_start": ["copyright"],
     "show_prev_next": False,
     "secondary_sidebar_items": ["page-toc"],


### PR DESCRIPTION
@Haleshot it looks like https://scipy.in now has two navbar rows after #92 because we have too many items in the navbar and the search button itself takes up a lot of space. I hope this sort of arrangement with a compact search bar is fine for now.