### PR TITLE
Redesign contact page

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -61,6 +61,56 @@ img.event-flyer-thumb {
   z-index: 2;
 }
 
+/* These are the volunteers' cards on the contact page: a circular GitHub avatar,
+   the person's name, and a row of icon links (GitHub, LinkedIn, email) in the
+   card footer. */
+.sci-team-grid .sd-card {
+  padding-top: 1.25rem;
+  text-align: center;
+}
+
+.sci-team-grid .sd-card-img-top {
+  flex: 0 0 auto;
+  align-self: center;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.sci-team-grid .sd-card-body {
+  padding-bottom: 0.5rem;
+}
+
+/* Increase the font size of the card footer for the icon links to be larger */
+.bd-content .sci-team-grid .sd-card .sd-card-footer {
+  font-size: 1.25rem;
+}
+
+.sci-team-grid .sd-card-footer p {
+  display: flex;
+  gap: 0.35rem;
+  justify-content: center;
+  margin: 0;
+}
+
+.sci-team-grid .sd-card-footer a {
+  display: inline-flex;
+  justify-content: center;
+  width: 1.5em;
+  padding: 0.15em 0;
+  border-top: max(3px, 0.1875rem, 0.12em) solid transparent;
+  border-bottom: max(3px, 0.1875rem, 0.12em) solid transparent;
+  color: var(--pst-color-text-muted);
+  text-decoration: none;
+}
+
+.sci-team-grid .sd-card-footer a:hover,
+.sci-team-grid .sd-card-footer a:focus-visible {
+  border-bottom-color: currentcolor;
+  color: var(--pst-color-link-hover);
+}
+
 .sci-collab-event-hero {
   margin: 1.5rem 0 3rem;
   padding: clamp(0.65rem, 2vw, 1.1rem);

--- a/docs/_static/team-shuffle.js
+++ b/docs/_static/team-shuffle.js
@@ -1,0 +1,19 @@
+// Shuffle the team cards on the contact page
+(() => {
+  const shuffle = () => {
+    document.querySelectorAll(".sci-team-grid .sd-row").forEach((row) => {
+      const cards = Array.from(row.children);
+      for (let i = cards.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [cards[i], cards[j]] = [cards[j], cards[i]];
+      }
+      row.append(...cards);
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", shuffle);
+  } else {
+    shuffle();
+  }
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,7 @@ html_static_path = ["_static"]
 # be careful with modifying this.
 html_extra_path = ["_extra"]
 html_css_files = ["custom.css"]
+html_js_files = [("team-shuffle.js", {"defer": "defer"})]
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_show_sourcelink = False

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -34,17 +34,6 @@ For general inquiries about SciPy India, collaboration opportunities, or if you'
 [{fab}`linkedin`](https://www.linkedin.com/in/agriyakhetarpal/)
 :::
 
-<!-- :::{grid-item-card}
-:img-top: https://github.com/Schefflera-Arboricola.png?size=400
-:img-alt: Aditi Juneja
-
-**Aditi Juneja**
-
-+++
-[{fab}`github`](https://github.com/Schefflera-Arboricola)
-[{fab}`linkedin`](https://linkedin.com/in/aditi-juneja-940838204)
-::: -->
-
 :::{grid-item-card}
 :img-top: https://github.com/rahulporuri.png?size=400
 :img-alt: Sai Rahul Poruri
@@ -68,3 +57,17 @@ For general inquiries about SciPy India, collaboration opportunities, or if you'
 :::
 
 ::::
+
+<!--
+
+:::{grid-item-card}
+:img-top: https://github.com/Schefflera-Arboricola.png?size=400
+:img-alt: Aditi Juneja
+
+**Aditi Juneja**
+
++++
+[{fab}`github`](https://github.com/Schefflera-Arboricola)
+[{fab}`linkedin`](https://linkedin.com/in/aditi-juneja-940838204)
+:::
+-->

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -8,28 +8,63 @@ myst:
 
 For general inquiries about SciPy India, collaboration opportunities, or if you're unsure who to contact, write to us at [info@scipy.in](mailto:info@scipy.in). You can also reach out to our community organisers and volunteers directly.
 
-::::{grid} 2
+::::{grid} 1 2 3 3
 :gutter: 3
+:class-container: sci-team-grid
 
-:::{grid-item-card} Srihari Thyagarajan
+:::{grid-item-card}
+:img-top: https://github.com/Haleshot.png?size=400
+:img-alt: Srihari Thyagarajan
 
-Co-organizer
+**Srihari Thyagarajan**
 
-[hari.leo03@gmail.com](mailto:hari.leo03@gmail.com)
++++
+[{fab}`github`](https://github.com/Haleshot)
+[{fab}`linkedin`](https://www.linkedin.com/in/srihari-thyagarajan/)
 :::
 
-:::{grid-item-card} Agriya Khetarpal
+:::{grid-item-card}
+:img-top: https://github.com/agriyakhetarpal.png?size=400
+:img-alt: Agriya Khetarpal
 
-Co-organizer
+**Agriya Khetarpal**
 
-[agriyakhetarpal@outlook.com](mailto:agriyakhetarpal@outlook.com)
++++
+[{fab}`github`](https://github.com/agriyakhetarpal)
+[{fab}`linkedin`](https://www.linkedin.com/in/agriyakhetarpal/)
 :::
 
-:::{grid-item-card} Aditi Juneja
+<!-- :::{grid-item-card}
+:img-top: https://github.com/Schefflera-Arboricola.png?size=400
+:img-alt: Aditi Juneja
 
-Volunteer
+**Aditi Juneja**
 
-[GitHub](https://github.com/Schefflera-Arboricola)
++++
+[{fab}`github`](https://github.com/Schefflera-Arboricola)
+[{fab}`linkedin`](https://linkedin.com/in/aditi-juneja-940838204)
+::: -->
+
+:::{grid-item-card}
+:img-top: https://github.com/rahulporuri.png?size=400
+:img-alt: Sai Rahul Poruri
+
+**Sai Rahul Poruri**
+
++++
+[{fab}`github`](https://github.com/rahulporuri)
+[{fab}`linkedin`](https://www.linkedin.com/in/rahulporuri/)
+:::
+
+:::{grid-item-card}
+:img-top: https://github.com/malayajac.png?size=400
+:img-alt: Malayaja Chutani
+
+**Malayaja Chutani**
+
++++
+[{fab}`github`](https://github.com/malayajac)
+[{fab}`linkedin`](https://www.linkedin.com/in/malayajachutani/)
 :::
 
 ::::


### PR DESCRIPTION
- Show current list of volunteers
- Add a grid based on https://theme.scientific-python.org/shortcodes/#grid (it shares the same design language as the PyData Sphinx Theme, in case you're wondering)
- Remove any mentions of organiser/volunteers and designations, and shuffle the cards so that we prevent ordering bias, since we have no clear hierarchy of roles, at least yet (and because shuffling is fun)
