### PR TITLE
Add an add-to-calendar option next to the homepage countdown

### DIFF
--- a/2026/_static/custom.css
+++ b/2026/_static/custom.css
@@ -12,6 +12,16 @@ I hope that we don't need to do this again for the foreseeable future */
   zoom: 0.72;
 }
 
+/* Anchors the "Important dates" instance of the add-to-calendar button
+next to the heading, the same way .sci-countdown does for the one up top */
+#important-dates {
+  position: relative;
+}
+
+#important-dates > .sci-add-to-calendar {
+  margin-top: 0;
+}
+
 /* Remove Sphinx's padding from figures that causes issues with the flip leaves */
 .flipdown figure {
   padding: 0;

--- a/2026/_static/custom.css
+++ b/2026/_static/custom.css
@@ -1,6 +1,7 @@
 /* Handling for the FlipDown time. This was not nice at all to figure out and
 I hope that we don't need to do this again for the foreseeable future */
 .sci-countdown {
+  position: relative;
   margin: 1.75rem 0 2rem;
   text-align: center;
 }
@@ -37,6 +38,83 @@ I hope that we don't need to do this again for the foreseeable future */
 
 .bd-content .flipdown.flipdown__theme-dark .rotor-group-heading:before {
   color: var(--pst-color-text-base);
+}
+
+/* Add-to-calendar dropdown below the countdown */
+.sci-add-to-calendar {
+  position: relative;
+  display: inline-block;
+  margin-top: 0.75rem;
+}
+
+.sci-add-to-calendar summary {
+  display: inline-block;
+  padding: 0.4rem 0.9rem;
+  border: 1px solid var(--pst-color-border);
+  border-radius: 999px;
+  color: var(--pst-color-text-base);
+  font-size: 0.9rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.sci-add-to-calendar summary::-webkit-details-marker {
+  display: none;
+}
+
+.sci-add-to-calendar summary:hover {
+  border-color: var(--pst-color-primary);
+  color: var(--pst-color-primary);
+}
+
+.sci-add-to-calendar[open] summary {
+  border-color: var(--pst-color-primary);
+  color: var(--pst-color-primary);
+}
+
+.sci-add-to-calendar a {
+  display: block;
+  padding: 0.5rem 1rem;
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+.sci-add-to-calendar a:not(:last-child) {
+  border-bottom: 1px solid var(--pst-color-border);
+}
+
+@media (min-width: 480px) {
+  .sci-add-to-calendar {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+
+  .sci-add-to-calendar[open]::before {
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    content: "";
+  }
+
+  .sci-add-to-calendar[open] .sci-add-to-calendar-menu,
+  .sci-add-to-calendar[open] summary {
+    position: relative;
+    z-index: 2;
+  }
+
+  .sci-add-to-calendar[open] .sci-add-to-calendar-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    min-width: 12rem;
+    margin-top: 0.25rem;
+    background: var(--pst-color-background);
+    border: 1px solid var(--pst-color-border);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px color-mix(in srgb, black, transparent 85%);
+    overflow: hidden;
+  }
 }
 
 .bd-content

--- a/2026/_static/scipy-india-2026.ics
+++ b/2026/_static/scipy-india-2026.ics
@@ -1,0 +1,15 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//SciPy India//2026 Conference//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:scipy-india-2026@scipy.in
+DTSTAMP:20260807T000000Z
+DTSTART;VALUE=DATE:20261219
+DTEND;VALUE=DATE:20261221
+SUMMARY:SciPy India 2026
+DESCRIPTION:An international scientific computing and open source software conference. Workshops on Saturday 19 December\, main conference day on Sunday 20 December.
+LOCATION:IIT Madras\, Chennai 600036\, India
+URL:https://scipy.in/2026/
+END:VEVENT
+END:VCALENDAR

--- a/2026/index.md
+++ b/2026/index.md
@@ -126,6 +126,21 @@ We are committed to providing a safe and welcoming environment for all attendees
 
 ## Important dates
 
+```{raw} html
+<details class="sci-add-to-calendar">
+  <summary>+ Add to calendar</summary>
+  <div class="sci-add-to-calendar-menu">
+    <a
+      href="https://www.google.com/calendar/render?action=TEMPLATE&text=SciPy+India+2026&dates=20261219/20261221&details=An+international+scientific+computing+and+open+source+software+conference.+Workshops+on+Saturday+19+December%2C+main+conference+day+on+Sunday+20+December.&location=IIT+Madras%2C+Chennai+600036%2C+India"
+      target="_blank"
+      rel="noopener"
+      >Google Calendar</a
+    >
+    <a href="_static/scipy-india-2026.ics" download>Apple / Outlook (.ics)</a>
+  </div>
+</details>
+```
+
 % TODO finalise these dates
 
 ```{eval-rst}

--- a/2026/index.md
+++ b/2026/index.md
@@ -38,6 +38,18 @@ Indian Institute of Technology Madras, Chennai 600036, Tamil Nadu, India
 ```{raw} html
 <div class="sci-countdown">
   <div id="flipdown" class="flipdown"></div>
+  <details class="sci-add-to-calendar">
+    <summary>+ Add to calendar</summary>
+    <div class="sci-add-to-calendar-menu">
+      <a
+        href="https://www.google.com/calendar/render?action=TEMPLATE&text=SciPy+India+2026&dates=20261219/20261221&details=An+international+scientific+computing+and+open+source+software+conference.+Workshops+on+Saturday+19+December%2C+main+conference+day+on+Sunday+20+December.&location=IIT+Madras%2C+Chennai+600036%2C+India"
+        target="_blank"
+        rel="noopener"
+        >Google Calendar</a
+      >
+      <a href="_static/scipy-india-2026.ics" download>Apple / Outlook (.ics)</a>
+    </div>
+  </details>
 </div>
 <script>
   document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
Thanks for the suggestion, @rahulporuri -- we're taking you up on it.
Adds a Google Calendar link and a downloadable `.ics` file for the conference dates, next to the countdown and the Important dates table.
